### PR TITLE
Sort scripts in panel

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
@@ -44,9 +44,9 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
@@ -221,11 +221,11 @@ public class ScriptInspector extends DevToolsFrame
 
 		try
 		{
-			blacklist = new HashSet<>(Lists.transform(Text.fromCSV(blacklistConfig), Integer::parseInt));
+			blacklist = new TreeSet<>(Lists.transform(Text.fromCSV(blacklistConfig), Integer::parseInt));
 		}
 		catch (NumberFormatException e)
 		{
-			blacklist = new HashSet<>(Lists.transform(Text.fromCSV(DEFAULT_BLACKLIST), Integer::parseInt));
+			blacklist = new TreeSet<>(Lists.transform(Text.fromCSV(DEFAULT_BLACKLIST), Integer::parseInt));
 		}
 
 		String highlightsConfig = configManager.getConfiguration("devtools", "highlights");
@@ -237,11 +237,11 @@ public class ScriptInspector extends DevToolsFrame
 
 		try
 		{
-			highlights = new HashSet<>(Lists.transform(Text.fromCSV(highlightsConfig), Integer::parseInt));
+			highlights = new TreeSet<>(Lists.transform(Text.fromCSV(highlightsConfig), Integer::parseInt));
 		}
 		catch (NumberFormatException e)
 		{
-			blacklist = new HashSet<>();
+			blacklist = new TreeSet<>();
 		}
 
 		final JPanel rightSide = new JPanel();
@@ -514,7 +514,7 @@ public class ScriptInspector extends DevToolsFrame
 	private void refreshList()
 	{
 		listModel.clear();
-		Set<Integer> set = getSet();
+		TreeSet<Integer> set = (TreeSet<Integer>) getSet();
 
 		for (Integer i : set)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/ScriptInspector.java
@@ -31,6 +31,9 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -235,7 +238,18 @@ public class ScriptInspector extends DevToolsFrame
 		listModel = new DefaultListModel<>();
 		changeState(ListState.BLACKLIST);
 		jList = new JList<>(listModel);
-		jList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		jList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+		jList.addKeyListener(new KeyAdapter()
+		{
+			@Override
+			public void keyPressed(KeyEvent e)
+			{
+				if (e.getKeyCode() == KeyEvent.VK_DELETE)
+				{
+					removeSelectedFromSet();
+				}
+			}
+		});
 		JScrollPane listScrollPane = new JScrollPane(jList);
 
 		final JButton blacklistButton = new JButton("Blacklist");
@@ -256,6 +270,26 @@ public class ScriptInspector extends DevToolsFrame
 		Component mySpinnerEditor = jSpinner.getEditor();
 		JFormattedTextField textField = ((JSpinner.DefaultEditor) mySpinnerEditor).getTextField();
 		textField.setColumns(5);
+
+		((JSpinner.DefaultEditor) mySpinnerEditor).getTextField().addKeyListener(new KeyAdapter()
+		{
+			@Override
+			public void keyPressed(KeyEvent e)
+			{
+				if (e.getKeyCode() == KeyEvent.VK_ENTER)
+				{
+					try
+					{
+						jSpinner.commitEdit();
+						addToSet(jSpinner);
+					}
+					catch (ParseException ex)
+					{
+						// ignore
+					}
+				}
+			}
+		});
 
 		final JButton addButton = new JButton("Add");
 		addButton.addActionListener(e -> addToSet(jSpinner));
@@ -424,8 +458,8 @@ public class ScriptInspector extends DevToolsFrame
 			return;
 		}
 
-		int script = listModel.get(index);
-		getSet().remove(script);
+		Set<Integer> set = getSet();
+		jList.getSelectedValuesList().forEach(set::remove);
 		refreshList();
 	}
 


### PR DESCRIPTION
I came across your PR in the RuneLite repository (RuneLite#<k>18237) and really enjoy the changes you present. I hope it's alright with you that, I ask you to add an additional QoL aspect to it.

The change this PR brings is using TreeSets instead of Sets for storing the script numbers, ensuring the scripts are always ordered in the GUI. This makes finding specific scripts in the blocklist or highlight list much easier, in my opinion.

Just after opening the PR I realized I had selected the wrong branch. If you want me to close this and re-open against your scripts branch, please let me know. Otherwise maybe you could just cherry-pick the commit and close this PR, if you still prefer the changes.
Sorry!